### PR TITLE
Need to load the testbed file to pyATS

### DIFF
--- a/bgp_adjacencies/BGP_Neighbors_Established.py
+++ b/bgp_adjacencies/BGP_Neighbors_Established.py
@@ -6,6 +6,9 @@ import json
 # To build the table at the end
 from tabulate import tabulate
 
+# Needed to import the testbed definition from file to pyATS
+from ats.topology import loader
+
 # Needed for aetest script
 from ats import aetest
 from ats.log.utils import banner
@@ -34,6 +37,7 @@ class common_setup(aetest.CommonSetup):
     # Connect to each device in the testbed
     @aetest.subsection
     def connect(self, testbed):
+        testbed = loader.load(testbed)
         genie_testbed = Genie.init(testbed)
         self.parent.parameters['testbed'] = genie_testbed
         device_list = []


### PR DESCRIPTION
Running `BGP_check_job.py` does not work out of the box. When running it with `pyats run job BGP_check_job.py --testbed_file default_testbed.yaml` the system complains that the testbed is NOT a pyATS testbed. 

```
❯ pyats run job BGP_check_job.py --testbed_file devnet_sandbox.yaml
2019-04-04T14:26:41: %EASYPY-INFO: Starting job run: BGP_check_job
2019-04-04T14:26:41: %EASYPY-INFO: Runinfo directory: /Users/jgomez2/dev/temp/netdevops/pyats/runinfo/BGP_check_job.2019Apr04_14:26:40.693242
2019-04-04T14:26:41: %EASYPY-INFO: --------------------------------------------------------------------------------
0+0 records in
0+0 records out
0 bytes transferred in 0.000011 secs (0 bytes/sec)
2019-04-04T14:26:43: %EASYPY-INFO: Starting task execution: Task-1
2019-04-04T14:26:43: %EASYPY-INFO:     test harness = pyats.aetest
2019-04-04T14:26:43: %EASYPY-INFO:     testscript   = /Users/jgomez2/dev/temp/netdevops/pyats/BGP_Neighbors_Established.py
2019-04-04T14:26:43: %AETEST-INFO: Starting common setup
2019-04-04T14:26:43: %AETEST-INFO: Starting subsection connect
2019-04-04T14:26:43: %AETEST-ERROR: Caught exception during execution:
2019-04-04T14:26:43: %AETEST-ERROR: Traceback (most recent call last):
2019-04-04T14:26:43: %AETEST-ERROR:   File "/Users/jgomez2/dev/temp/netdevops/pyats/BGP_Neighbors_Established.py", line 37, in connect
2019-04-04T14:26:43: %AETEST-ERROR:     genie_testbed = Genie.init(testbed)
2019-04-04T14:26:43: %AETEST-ERROR:   File "src/genie/conf/main.py", line 72, in genie.conf.main.Genie.init
2019-04-04T14:26:43: %AETEST-ERROR: TypeError: Argument should be a pyATS Testbed object but received object of type <class 'NoneType'>
```

The script tries to load it directly with the `Genie.init(testbed)`, but it needs first to load from the file to pyATS with `loader.load(testbed)`. With this mod (and importing the `loader` lib, of course), everything works well.