### PR TITLE
more comprehensive 'established' status

### DIFF
--- a/bgp_adjacencies/BGP_Neighbors_Established.py
+++ b/bgp_adjacencies/BGP_Neighbors_Established.py
@@ -91,7 +91,7 @@ class BGP_Neighbors_Established(aetest.Testcase):
                     tr.append(device)
                     tr.append(nbr)
                     tr.append(state)
-                    if state == 'established':
+                    if state == 'established' or state == 'Established':
                         tr.append('Passed')
                     else:
                         failed_dict[device] = {}


### PR DESCRIPTION
'established' or 'Established' should be accepted to pass the test... otherwise it fails:

```
2019-05-06T21:04:35: %SCRIPT-INFO: | Device     | Peer     | State       | Pass/Fail   |
2019-05-06T21:04:35: %SCRIPT-INFO: |------------+----------+-------------+-------------|
2019-05-06T21:04:35: %SCRIPT-INFO: | csr1000v-1 | 10.2.2.2 | Established | Passed      |
2019-05-06T21:04:35: %SCRIPT-INFO: | nx-osv-1   | 10.1.1.1 | established | Passed      |
```