### PR TITLE
modified BGP and CRC - remove abstract

### DIFF
--- a/bgp_adjacencies/BGP_Neighbors_Established.py
+++ b/bgp_adjacencies/BGP_Neighbors_Established.py
@@ -12,10 +12,7 @@ from ats.log.utils import banner
 
 # Genie Imports
 from genie.conf import Genie
-from genie.abstract import Lookup
 
-# import the genie libs
-from genie.libs import ops # noqa
 
 # Get your logger for your script
 log = logging.getLogger(__name__)
@@ -69,9 +66,7 @@ class BGP_Neighbors_Established(aetest.Testcase):
         for dev in self.parent.parameters['dev']:
             log.info(banner("Gathering BGP Information from {}".format(
                 dev.name)))
-            abstract = Lookup.from_device(dev)
-            bgp = abstract.ops.bgp.bgp.Bgp(dev)
-            bgp.learn()
+            bgp = dev.learn('bgp')
             self.all_bgp_sessions[dev.name] = bgp.info
 
     @ aetest.test

--- a/crc_errors/CRC_Count_check.py
+++ b/crc_errors/CRC_Count_check.py
@@ -12,10 +12,7 @@ from ats.log.utils import banner
 
 # Genie Imports
 from genie.conf import Genie
-from genie.abstract import Lookup
 
-# import the genie libs
-from genie.libs import ops # noqa
 
 # Get your logger for your script
 log = logging.getLogger(__name__)
@@ -69,9 +66,7 @@ class CRC_count_check(aetest.Testcase):
         for dev in self.parent.parameters['dev']:
             log.info(banner("Gathering Interface Information from {}".format(
                 dev.name)))
-            abstract = Lookup.from_device(dev)
-            intf = abstract.ops.interface.interface.Interface(dev)
-            intf.learn()
+            intf = dev.learn('interface')
             self.all_interfaces[dev.name] = intf.info
 
     # Second test section


### PR DESCRIPTION
Hi Kevin, 
There is no longer a requirement to leverage the Abstract Lookup class, nor import model (ops) libraries.  The syntax has been simplified, so all you need to do for interfaces is. 
```
intf = uut.learn('interface')
```
This will works in pyATS/GENIE 19+, so the requirements.txt file may need to be amended.

I have tested the changes and they work as expected. 